### PR TITLE
.gitignore README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ MANIFEST*
 *~
 *.bak
 *.tar.gz
+# Generated from Makefile.PL with pod2text
+/README


### PR DESCRIPTION
Add `README` to `.gitignore` as this file is generated and must not be committed.